### PR TITLE
Hook args are HTML-escaped

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -111,6 +111,14 @@ module.exports = function(grunt) {
         'pre-commit': 'aTask'
       },
 
+      'test.withQuotedArguments': {
+        options: {
+          dest: 'tmp/withQuotedArguments',
+          args: '--test "foo \'bar baz\'"'
+        },
+        'pre-commit': 'aTask'
+      },
+
       'test.hookSpecificOptions': {
 
         options: {

--- a/lib/escapeBackslashes.handlebars.js
+++ b/lib/escapeBackslashes.handlebars.js
@@ -2,5 +2,5 @@
 
 module.exports = function (object) {
 
-  return object.toString().replace(/\\/g,'\\\\');
+  return object.toString().replace(/\\/g,'\\\\').replace(/'/g,'\\\'');
 };

--- a/templates/node.js.hb
+++ b/templates/node.js.hb
@@ -1,6 +1,6 @@
 var exec = require('child_process').exec;
 
-exec('{{escapeBackslashes command}}{{#if task}} {{escapeBackslashes task}}{{/if}}{{#if args}} {{escapeBackslashes args}}{{/if}}', {
+exec('{{escapeBackslashes command}}{{#if task}} {{escapeBackslashes task}}{{/if}}{{#if args}} {{{escapeBackslashes args}}}{{/if}}', {
        cwd: '{{escapeBackslashes gruntfileDirectory}}'
      }, function (err, stdout, stderr) {
   

--- a/test/expected/pre-commit.withQuotedArguments
+++ b/test/expected/pre-commit.withQuotedArguments
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+
+// GRUNT-GITHOOKS START
+var exec = require('child_process').exec;
+
+exec('grunt aTask --test "foo \'bar baz\'"', {
+       cwd: '{{expectedWorkingDir}}'
+     }, function (err, stdout, stderr) {
+  
+  console.log(stdout);
+
+  var exitCode = 0;
+  if (err) {
+    console.log(stderr);
+    exitCode = -1;
+  }
+
+  process.exit(exitCode);
+});
+// GRUNT-GITHOOKS END


### PR DESCRIPTION
Consider the following hook definition:

```
'pre-commit': {
    taskNames: 'jshint',
    args: '--files="$(git diff --cached --name-only -diff-filter=ACM)"'
}
```

It yields the following command from the default template:

```
'grunt jshint --files=&quot;$(git diff --cached --name-only -diff-filter=ACM)&quot;'
```

... which obviously does not execute correctly, as the shell knows no HTML encoding.
