### PR TITLE
replace exec with spawn

### DIFF
--- a/templates/node.js.hb
+++ b/templates/node.js.hb
@@ -1,16 +1,14 @@
-var exec = require('child_process').exec;
+var spawn = require('child_process').spawn;
 
-exec('{{escapeBackslashes command}}{{#if task}} {{escapeBackslashes task}}{{/if}}{{#if args}} {{{escapeBackslashes args}}}{{/if}}', {
-       cwd: '{{escapeBackslashes gruntfileDirectory}}'
-     }, function (err, stdout, stderr) {
-  
-  console.log(stdout);
+var grunt_process = spawn(
+  '{{escapeBackslashes command}}',
+  [ {{#if task}}'{{escapeBackslashes task}}'{{/if}}  ].concat({{#if args}}'{{{escapeBackslashes args}}}'.split(' '){{/if}}),
+  {
+    cwd: '{{escapeBackslashes gruntfileDirectory}}',
+    stdio: 'inherit'
+  }
+);
 
-  var exitCode = 0;
-  if (err) {
-    console.log(stderr);
-    exitCode = -1;
-  }{{#unless preventExit}}
-
-  process.exit(exitCode);{{/unless}}
+grunt_process.on('close', function(exitCode) {
+  {{#unless preventExit}}process.exit(exitCode);{{/unless}}
 });


### PR DESCRIPTION
This should fix the issues described in #9.

I successfully tested streaming the output of a long-running grunt task, but cannot confirm the windows issue because I don't have access to a windows box. Note that I did not adapt the tests yet as adapting the expected outcome files is going to be a huge PITA and I wanted to get early feedback (maybe we could also think of a better way to test the outcome instead, e.g. we could parse expected and actual with esprima and compare the tree so we don't have to reproduce up to the last whitespace etc)
