### PR TITLE
Fix: pipe stdout from commit hook tasks while running 

### DIFF
--- a/templates/node.js.hb
+++ b/templates/node.js.hb
@@ -4,8 +4,6 @@ exec('{{escapeBackslashes command}}{{#if task}} {{escapeBackslashes task}}{{/if}
        cwd: '{{escapeBackslashes gruntfileDirectory}}'
      }, function (err, stdout, stderr) {
 
-  console.log(stdout);
-
   var exitCode = 0;
   if (err) {
     console.log(stderr || err);

--- a/templates/node.js.hb
+++ b/templates/node.js.hb
@@ -13,4 +13,6 @@ exec('{{escapeBackslashes command}}{{#if task}} {{escapeBackslashes task}}{{/if}
   }{{#unless preventExit}}
 
   process.exit(exitCode);{{/unless}}
+}).stdout.on('data', function (chunk){
+    process.stdout.write(chunk);
 });

--- a/test/expected/commit-msg.multipleHooks
+++ b/test/expected/commit-msg.multipleHooks
@@ -7,8 +7,6 @@ exec('grunt anotherTask', {
        cwd: '{{expectedWorkingDir}}'
      }, function (err, stdout, stderr) {
 
-  console.log(stdout);
-
   var exitCode = 0;
   if (err) {
     console.log(stderr || err);

--- a/test/expected/commit-msg.multipleHooks
+++ b/test/expected/commit-msg.multipleHooks
@@ -16,5 +16,7 @@ exec('grunt anotherTask', {
   }
 
   process.exit(exitCode);
+}).stdout.on('data', function (chunk){
+    process.stdout.write(chunk);
 });
 // GRUNT-GITHOOKS END

--- a/test/expected/pre-commit.append
+++ b/test/expected/pre-commit.append
@@ -9,8 +9,6 @@ exec('grunt aTask', {
        cwd: '{{expectedWorkingDir}}'
      }, function (err, stdout, stderr) {
 
-  console.log(stdout);
-
   var exitCode = 0;
   if (err) {
     console.log(stderr || err);

--- a/test/expected/pre-commit.append
+++ b/test/expected/pre-commit.append
@@ -18,5 +18,7 @@ exec('grunt aTask', {
   }
 
   process.exit(exitCode);
+}).stdout.on('data', function (chunk){
+    process.stdout.write(chunk);
 });
 // GRUNT-GITHOOKS END

--- a/test/expected/pre-commit.command
+++ b/test/expected/pre-commit.command
@@ -16,5 +16,7 @@ exec('/usr/bin/grunt aTask', {
   }
 
   process.exit(exitCode);
+}).stdout.on('data', function (chunk){
+    process.stdout.write(chunk);
 });
 // GRUNT-GITHOOKS END

--- a/test/expected/pre-commit.command
+++ b/test/expected/pre-commit.command
@@ -7,8 +7,6 @@ exec('/usr/bin/grunt aTask', {
        cwd: '{{expectedWorkingDir}}'
      }, function (err, stdout, stderr) {
 
-  console.log(stdout);
-
   var exitCode = 0;
   if (err) {
     console.log(stderr || err);

--- a/test/expected/pre-commit.customHashbang
+++ b/test/expected/pre-commit.customHashbang
@@ -16,5 +16,7 @@ exec('grunt aTask', {
   }
 
   process.exit(exitCode);
+}).stdout.on('data', function (chunk){
+    process.stdout.write(chunk);
 });
 // GRUNT-GITHOOKS END

--- a/test/expected/pre-commit.customHashbang
+++ b/test/expected/pre-commit.customHashbang
@@ -7,8 +7,6 @@ exec('grunt aTask', {
        cwd: '{{expectedWorkingDir}}'
      }, function (err, stdout, stderr) {
 
-  console.log(stdout);
-
   var exitCode = 0;
   if (err) {
     console.log(stderr || err);

--- a/test/expected/pre-commit.customTemplate
+++ b/test/expected/pre-commit.customTemplate
@@ -6,8 +6,6 @@ var exec = require('child_process').exec;
 
 exec('grunt aTask', function (err, stdout, stderr) {
 
-  console.log(stdout);
-
   var exitCode = 0;
   if (err) {
     console.log(stderr || err);

--- a/test/expected/pre-commit.customTemplate
+++ b/test/expected/pre-commit.customTemplate
@@ -15,5 +15,7 @@ exec('grunt aTask', function (err, stdout, stderr) {
   }
 
   process.exit(exitCode);
+}).stdout.on('data', function (chunk){
+    process.stdout.write(chunk);
 });
 // GRUNT-GITHOOKS END

--- a/test/expected/pre-commit.default
+++ b/test/expected/pre-commit.default
@@ -16,5 +16,7 @@ exec('grunt aTask', {
   }
 
   process.exit(exitCode);
+}).stdout.on('data', function (chunk){
+    process.stdout.write(chunk);
 });
 // GRUNT-GITHOOKS END

--- a/test/expected/pre-commit.default
+++ b/test/expected/pre-commit.default
@@ -7,8 +7,6 @@ exec('grunt aTask', {
        cwd: '{{expectedWorkingDir}}'
      }, function (err, stdout, stderr) {
 
-  console.log(stdout);
-
   var exitCode = 0;
   if (err) {
     console.log(stderr || err);

--- a/test/expected/pre-commit.hookSpecificOptions
+++ b/test/expected/pre-commit.hookSpecificOptions
@@ -6,8 +6,6 @@ var exec = require('child_process').exec;
 
 exec('grunt aTask', function (err, stdout, stderr) {
 
-  console.log(stdout);
-
   var exitCode = 0;
   if (err) {
     console.log(stderr || err);

--- a/test/expected/pre-commit.hookSpecificOptions
+++ b/test/expected/pre-commit.hookSpecificOptions
@@ -15,5 +15,7 @@ exec('grunt aTask', function (err, stdout, stderr) {
   }
 
   process.exit(exitCode);
+}).stdout.on('data', function (chunk){
+    process.stdout.write(chunk);
 });
 // GRUNT-GITHOOKS END

--- a/test/expected/pre-commit.insert
+++ b/test/expected/pre-commit.insert
@@ -17,6 +17,8 @@ exec('grunt aTask', {
     console.log(stderr || err);
     exitCode = -1;
   }
+}).stdout.on('data', function (chunk){
+    process.stdout.write(chunk);
 });
 // GRUNT-GITHOOKS END
 

--- a/test/expected/pre-commit.insert
+++ b/test/expected/pre-commit.insert
@@ -10,8 +10,6 @@ exec('grunt aTask', {
        cwd: '{{expectedWorkingDir}}'
      }, function (err, stdout, stderr) {
 
-  console.log(stdout);
-
   var exitCode = 0;
   if (err) {
     console.log(stderr || err);

--- a/test/expected/pre-commit.multipleHooks
+++ b/test/expected/pre-commit.multipleHooks
@@ -16,5 +16,7 @@ exec('grunt aTask', {
   }
 
   process.exit(exitCode);
+}).stdout.on('data', function (chunk){
+    process.stdout.write(chunk);
 });
 // GRUNT-GITHOOKS END

--- a/test/expected/pre-commit.multipleHooks
+++ b/test/expected/pre-commit.multipleHooks
@@ -7,8 +7,6 @@ exec('grunt aTask', {
        cwd: '{{expectedWorkingDir}}'
      }, function (err, stdout, stderr) {
 
-  console.log(stdout);
-
   var exitCode = 0;
   if (err) {
     console.log(stderr || err);

--- a/test/expected/pre-commit.multiple_tasks
+++ b/test/expected/pre-commit.multiple_tasks
@@ -7,8 +7,6 @@ exec('grunt aTask anotherTask', {
        cwd: '{{expectedWorkingDir}}'
      }, function (err, stdout, stderr) {
 
-  console.log(stdout);
-
   var exitCode = 0;
   if (err) {
     console.log(stderr || err);

--- a/test/expected/pre-commit.multiple_tasks
+++ b/test/expected/pre-commit.multiple_tasks
@@ -16,5 +16,7 @@ exec('grunt aTask anotherTask', {
   }
 
   process.exit(exitCode);
+}).stdout.on('data', function (chunk){
+    process.stdout.write(chunk);
 });
 // GRUNT-GITHOOKS END

--- a/test/expected/pre-commit.noTaskNames
+++ b/test/expected/pre-commit.noTaskNames
@@ -7,8 +7,6 @@ exec('grunt', {
        cwd: '{{expectedWorkingDir}}'
      }, function (err, stdout, stderr) {
 
-  console.log(stdout);
-
   var exitCode = 0;
   if (err) {
     console.log(stderr || err);

--- a/test/expected/pre-commit.noTaskNames
+++ b/test/expected/pre-commit.noTaskNames
@@ -14,5 +14,7 @@ exec('grunt', {
     console.log(stderr || err);
     exitCode = -1;
   }
+}).stdout.on('data', function (chunk){
+    process.stdout.write(chunk);
 });
 // GRUNT-GITHOOKS END

--- a/test/expected/pre-commit.withArguments
+++ b/test/expected/pre-commit.withArguments
@@ -7,8 +7,6 @@ exec('grunt aTask --test myargument', {
        cwd: '{{expectedWorkingDir}}'
      }, function (err, stdout, stderr) {
 
-  console.log(stdout);
-
   var exitCode = 0;
   if (err) {
     console.log(stderr || err);

--- a/test/expected/pre-commit.withArguments
+++ b/test/expected/pre-commit.withArguments
@@ -16,5 +16,7 @@ exec('grunt aTask --test myargument', {
   }
 
   process.exit(exitCode);
+}).stdout.on('data', function (chunk){
+    process.stdout.write(chunk);
 });
 // GRUNT-GITHOOKS END

--- a/test/expected/pre-commit.withQuotedArguments
+++ b/test/expected/pre-commit.withQuotedArguments
@@ -7,8 +7,6 @@ exec('grunt aTask --test "foo \'bar baz\'"', {
        cwd: '{{expectedWorkingDir}}'
      }, function (err, stdout, stderr) {
 
-  console.log(stdout);
-
   var exitCode = 0;
   if (err) {
     console.log(stderr || err);

--- a/test/expected/pre-commit.withQuotedArguments
+++ b/test/expected/pre-commit.withQuotedArguments
@@ -16,5 +16,7 @@ exec('grunt aTask --test "foo \'bar baz\'"', {
   }
 
   process.exit(exitCode);
+}).stdout.on('data', function (chunk){
+    process.stdout.write(chunk);
 });
 // GRUNT-GITHOOKS END

--- a/test/fixtures/custom-template.js.hb
+++ b/test/fixtures/custom-template.js.hb
@@ -3,8 +3,6 @@ var exec = require('child_process').exec;
 
 exec('grunt {{task}}', function (err, stdout, stderr) {
 
-  console.log(stdout);
-
   var exitCode = 0;
   if (err) {
     console.log(stderr || err);

--- a/test/fixtures/custom-template.js.hb
+++ b/test/fixtures/custom-template.js.hb
@@ -12,4 +12,6 @@ exec('grunt {{task}}', function (err, stdout, stderr) {
   }
 
   process.exit(exitCode);
+}).stdout.on('data', function (chunk){
+    process.stdout.write(chunk);
 });


### PR DESCRIPTION
Adding this...

```javascript
.stdout.on('data', function (chunk){
    process.stdout.write(chunk);
});
```

Makes the output come back realtime.

Fixes https://github.com/wecodemore/grunt-githooks/issues/18

