### PR TITLE
Simplify package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,19 +18,8 @@
 			"url"  : "http://rhumaric.com"
 		}
 	],
-	"repository"       : {
-		"type" : "git",
-		"url"  : "git://github.com/wecodemore/grunt-githooks.git"
-	},
-	"bugs"             : {
-		"url" : "https://github.com/wecodemore/grunt-githooks/issues"
-	},
-	"licenses"         : [
-		{
-			"type" : "MIT",
-			"url"  : "https://github.com/wecodemore/grunt-githooks/blob/master/LICENSE-MIT"
-		}
-	],
+	"repository"       : "wecodemore/grunt-githooks",
+	"license"          : "MIT",
 	"main"             : "Gruntfile.js",
 	"engines"          : {
 		"node" : ">= 0.8.0"


### PR DESCRIPTION
"bugs" field is not needed as npm infers it from the repo URL