### PR TITLE
Update peerDependencies to support Grunt 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 		"grunt-contrib-copy"     : "~0.4.1"
 	},
 	"peerDependencies" : {
-		"grunt" : "~0.4.1"
+		"grunt" : ">=0.4.1"
 	},
 	"keywords"         : [
 		"gruntplugin",


### PR DESCRIPTION
This PR updates the peerDependencies for Grunt to allow compatibility with Grunt 1.0.0 and later.

This is in line with guidance from the Grunt team about how peerDependencies should be updated for the Grunt 1.0.0 release. See more here:
http://gruntjs.com/blog/2016-02-11-grunt-1.0.0-rc1-released#peer-dependencies
https://twitter.com/gruntjs/status/700819604155707392

This PR will resolve the following error during `npm install` when using grunt-githooks with Grunt 1.x:
```
npm ERR! code EPEERINVALID
npm ERR! peerinvalid The package grunt@1.0.1 does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer grunt-githooks@0.5.0 wants grunt@~0.4.1
```

I'd appreciate if this change could be released in a new version to npm, as it will solve this critical install issue for Grunt 1.x users.

Thanks!
